### PR TITLE
feat-予報ページのUIテストを追加しました

### DIFF
--- a/DiscomfortIndexApp/View/Base.lproj/Main.storyboard
+++ b/DiscomfortIndexApp/View/Base.lproj/Main.storyboard
@@ -162,6 +162,7 @@
                             </stackView>
                         </subviews>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <accessibility key="accessibilityConfiguration" identifier="weather_view"/>
                         <constraints>
                             <constraint firstItem="rZS-Le-nkl" firstAttribute="top" secondItem="8bC-Xf-vdC" secondAttribute="top" id="2vU-uF-tVm"/>
                             <constraint firstAttribute="bottom" secondItem="rZS-Le-nkl" secondAttribute="bottom" id="7rm-qE-ohw"/>
@@ -671,6 +672,7 @@
                             </stackView>
                         </subviews>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <accessibility key="accessibilityConfiguration" identifier="forecast_view"/>
                         <constraints>
                             <constraint firstItem="OJg-Ak-d52" firstAttribute="leading" secondItem="G0C-Sh-BWb" secondAttribute="leading" id="3b5-ll-Ie7"/>
                             <constraint firstItem="fv6-W6-bk4" firstAttribute="leading" secondItem="e6a-Ft-hiE" secondAttribute="leading" id="D4R-ra-VCM"/>

--- a/DiscomfortIndexAppUITests/DiscomfortIndexAppUITests.swift
+++ b/DiscomfortIndexAppUITests/DiscomfortIndexAppUITests.swift
@@ -34,4 +34,26 @@ class DiscomfortIndexAppUITests: XCTestCase {
         XCTAssertEqual(cityLabel.label, "Sapporo")
     }
 
+    func testForecast() {
+        let app = XCUIApplication()
+        let searchTextField = app.textFields["forecast_textfield"]
+        let searchButton = app.buttons["forecast_search_button"]
+        let cityLabel = app.staticTexts["forecast_city_label"]
+
+        // スワイプして予報ページに移動
+        app.otherElements["weather_view"].swipeLeft()
+
+        XCTAssert(searchTextField.exists)
+        XCTAssert(searchButton.exists)
+        XCTAssert(cityLabel.exists)
+
+        searchTextField.tap()
+        searchTextField.typeText("sapporo")
+        searchButton.tap()
+
+        // 都市名ラベルが更新されるまでの待機時間として２秒を設定
+        sleep(2)
+        XCTAssertEqual(cityLabel.label, "Sapporo")
+    }
+
 }


### PR DESCRIPTION
ページをスワイプ操作するために、各ページのViewのAccessibility Identifierも設定しました。